### PR TITLE
Improve cleanup steps

### DIFF
--- a/scripts/99_cleanup_resources.sh
+++ b/scripts/99_cleanup_resources.sh
@@ -11,6 +11,25 @@ delete_file() {
  rm -f $WORKING_DIR/$1
 }
 
+# Deletes the CloudFormation stack created by eksctl
+#
+delete_eksctl_cf_stack() {
+  local cluster_name=$1
+  local stack_name="eksctl-$cluster_name-cluster"
+  local out=$(aws cloudformation describe-stacks --region $CONFIG_REGION | jq -r --arg sn "$stack_name" \
+   '.Stacks[]|select(.StackName==$sn)|.StackName')
+
+  [[ "$out" == "$stack_name" ]] && {
+      say_warn "Attempt to delete cloud formation stack created by eksctl..."
+      aws cloudformation delete-stack --stack-name $stack_name --region $CONFIG_REGION && {
+      return $SUCCESS
+    }
+  }
+
+  say_err "Cannot delete cloud formation stack: $stack_name"
+  return $FAILURE
+}
+
 ####################################################
 # Main
 ####################################################
@@ -21,19 +40,25 @@ main() {
 
   say "Attempt to delete cluster node group: $CONFIG_EKS_WORKER_NODE_NAME"
 
+  local cf_stack_delete=false
   eksctl delete nodegroup --cluster=$CONFIG_EKS_CLUSTER_NAME --name=$CONFIG_EKS_WORKER_NODE_NAME \
     --region $CONFIG_REGION || $FLAG_IGNORE_ERRORS || {
-      say_err "Cluster node group cannot be deleted."
-      return $FAILURE
+      say_warn "Cluster node group cannot be deleted. Trying to delete CloudFormation stack..."
+      delete_eksctl_cf_stack $CONFIG_EKS_CLUSTER_NAME && {
+        say "CloudFormation deletion has been triggered successfully!"
+        cf_stack_delete=true
+      }
     }
 
-  say "Attempt to delete cluster: $CONFIG_EKS_WORKER_NODE_NAME"
+  [[ "$cf_stack_delete" != true ]] && {
+    say "Attempt to delete cluster: $CONFIG_EKS_WORKER_NODE_NAME"
 
-  eksctl delete cluster --name $CONFIG_EKS_CLUSTER_NAME \
-    --region $CONFIG_REGION || $FLAG_IGNORE_ERRORS || {
-      say_err "Cluster cannot be deleted."
-      return $FAILURE
-    }
+    eksctl delete cluster --name $CONFIG_EKS_CLUSTER_NAME \
+      --region $CONFIG_REGION || $FLAG_IGNORE_ERRORS || {
+        say_err "Cluster cannot be deleted."
+        return $FAILURE
+      }
+  }
 
   local lt_name="lt_$CONFIG_SETUP_UUID"
   local lt_id=$(get_launch_template_id $lt_name)


### PR DESCRIPTION
- Try to delete cloudformation stack created by eksctl if the attempt to delete the node group fails.

Signed-off-by: Erdem Meydanli <meydanli@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
