### PR TITLE
Update Dependency Checks

### DIFF
--- a/nectl
+++ b/nectl
@@ -75,8 +75,20 @@ cmd_help() {
   say "$USAGE"
 }
 
+# Ensure basic dependencies of the project are installed.
+ensure_basic_deps() {
+  which docker > /dev/null 2>&1
+  ok_or_die "docker not found. Aborting." \
+      "Please make sure you have docker installed. For more information, see" \
+      "https://docs.docker.com/desktop/install/linux-install"
+
+  which jq > /dev/null 2>&1
+  ok_or_die "jq not found. Aborting." \
+  "Please make sure you have jq package installed."
+}
+
 # Ensure eksctl and kubectl are available on this deployment machine
-ensure_deps() {
+ensure_eks_deps() {
   which eksctl > /dev/null 2>&1
   ok_or_die "eksctl not found. Aborting." \
       "Please make sure you have eksctl installed. For more information, see" \
@@ -86,15 +98,6 @@ ensure_deps() {
   ok_or_die "kubectl not found. Aborting." \
       "Please make sure you have kubectl installed. For more information, see" \
       "https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html."
-
-  which docker > /dev/null 2>&1
-  ok_or_die "docker not found. Aborting." \
-      "Please make sure you have docker installed. For more information, see" \
-      "https://docs.docker.com/desktop/install/linux-install"
-
-  which jq > /dev/null 2>&1
-  ok_or_die "jq not found. Aborting." \
-  "Please make sure you have jq package installed."
 }
 
 exec_subscript() {
@@ -319,28 +322,36 @@ main() {
     exit 1
   fi
 
-  # Ensure dependencies
-  ensure_deps
+  # Ensure basic dependencies
+  ensure_basic_deps
   # Try loading applied settings.
   try_load_configuration
 
   local cmd="$1"
   case "$1" in
-   -h|help)
-       cmd_help
-       exit 1
-       ;;
+    -h|help)
+     cmd_help
+     exit 1
+     ;;
    -c|configure)
-       shift
-       cmd_configure "$@"
-       ;;
+     shift
+     cmd_configure "$@"
+     ;;
    *)
-       declare -f "cmd_$cmd" > /dev/null
-       ok_or_die "Unknown command: $1. Please use \`$MY_NAME help\` for help."
-       [[ ! -f $WORKING_DIR/$FILE_CONFIGURATION ]] && \
-           die "The demo hasn't been configured yet. Please use \`$MY_NAME help\` to know how to configure."
-       cmd_"$@"
-       ;;
+     declare -f "cmd_$cmd" > /dev/null
+     ok_or_die "Unknown command: $1. Please use \`$MY_NAME help\` for help."
+
+     case "$1" in
+       setup|run|stop)
+        ensure_eks_deps
+        ;;
+     esac
+
+     [[ ! -f $WORKING_DIR/$FILE_CONFIGURATION ]] && \
+       die "The demo hasn't been configured yet. Please use \`$MY_NAME help\` to know how to configure."
+
+     cmd_"$@"
+     ;;
   esac
 }
 

--- a/scripts/99_cleanup_resources.sh
+++ b/scripts/99_cleanup_resources.sh
@@ -11,15 +11,11 @@ delete_file() {
  rm -f $WORKING_DIR/$1
 }
 
-####################################################
-# Main
-####################################################
+is_eksctl_installed() {
+  which eksctl 2>&1 > /dev/null
+}
 
-main() {
-  local force_cleanup=$1
-  #TODO: Delete the ECR repository
-  #TODO: Delete docker images
-
+delete_eks_resources() {
   say "Attempt to delete cluster node group: $CONFIG_EKS_WORKER_NODE_NAME"
 
   eksctl delete nodegroup --cluster=$CONFIG_EKS_CLUSTER_NAME --name=$CONFIG_EKS_WORKER_NODE_NAME \
@@ -35,6 +31,20 @@ main() {
       say_err "Cluster cannot be deleted."
       return $FAILURE
     }
+}
+
+####################################################
+# Main
+####################################################
+
+main() {
+  local force_cleanup=$1
+  #TODO: Delete the ECR repository
+  #TODO: Delete docker images
+
+  is_eksctl_installed && {
+    delete_eks_resources $force_cleanup
+  }
 
   local lt_name="lt_$CONFIG_SETUP_UUID"
   local lt_id=$(get_launch_template_id $lt_name)


### PR DESCRIPTION
To allow non-EKS users to build their NE application images via nectl, reorganize dependency checks so that the build, push, cleanup commands can run without having eksctl installed on the host machine.

Signed-off-by: Erdem Meydanli <meydanli@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
