### PR TITLE
Update the launch template

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,16 @@ To get some help for the tool, type:
 nectl --help
 ```
 
-The default settings for **nectl** are stored in **settings.json**. The content of this file is shown below. You can change the AWS region, the instance type of the cluster nodes, **Kubernetes** version, cluster name and node group name if wanted.
+The default settings for **nectl** are stored in **settings.json**. The content of this file is shown below. You can change the AWS region, the instance type of the cluster nodes, **Kubernetes** version, cluster name, cluster node group name, the maximum numbers of CPU cores that enclave can use and the node-level memory limit for enclave if wanted.
 ```
 {
   "region" : "eu-central-1",
   "instance_type" : "m5.2xlarge",
   "eks_cluster_name" : "eks-ne-cluster",
   "eks_worker_node_name" : "eks-ne-nodegroup",
-  "k8s_version" : "1.22"
+  "k8s_version" : "1.22",
+  "node_enclave_cpu_limit": 2,
+  "node_enclave_memory_limit_mib": 768
 }
 ```
 <br />

--- a/container/hello/hooks.sh
+++ b/container/hello/hooks.sh
@@ -35,7 +35,6 @@ spec:
           limits:
             aws.ec2.nitro/nitro_enclaves: "1"
             hugepages-2Mi: 512Mi
-            memory: 2Gi
             cpu: 250m
           requests:
             aws.ec2.nitro/nitro_enclaves: "1"
@@ -44,15 +43,18 @@ spec:
         - mountPath: /dev/hugepages
           name: hugepage
           readOnly: false
+      volumes:
+        - name: hugepage-2mi
+        emptyDir:
+          medium: HugePages-2Mi
+        - name: hugepage-1gi
+        emptyDir:
+          medium: HugePages-1Gi
       tolerations:
       - effect: NoSchedule
         operator: Exists
       - effect: NoExecute
         operator: Exists
-      volumes:
-        - name: hugepage
-          emptyDir:
-            medium: HugePages
 EOF
 )
   # Create deployment yaml file

--- a/container/kms/hooks.sh
+++ b/container/kms/hooks.sh
@@ -36,7 +36,6 @@ spec:
           limits:
             aws.ec2.nitro/nitro_enclaves: "1"
             hugepages-2Mi: 768Mi
-            memory: 2Gi
             cpu: 250m
           requests:
             aws.ec2.nitro/nitro_enclaves: "1"
@@ -45,15 +44,18 @@ spec:
         - mountPath: /dev/hugepages
           name: hugepage
           readOnly: false
+      volumes:
+        - name: hugepage-2mi
+        emptyDir:
+          medium: HugePages-2Mi
+        - name: hugepage-1gi
+        emptyDir:
+          medium: HugePages-1Gi
       tolerations:
       - effect: NoSchedule
         operator: Exists
       - effect: NoExecute
         operator: Exists
-      volumes:
-        - name: hugepage
-          emptyDir:
-            medium: HugePages
 EOF
 )
 

--- a/nectl
+++ b/nectl
@@ -9,7 +9,7 @@ MY_DESC="AWS Nitro Enclaves with K8s utility tool"
 source "$(dirname $(realpath $0))/scripts/common.sh"
 
 # Configuration items
-CONFIG_NAMES=(region instance_type eks_cluster_name eks_worker_node_name k8s_version)
+CONFIG_NAMES=(region instance_type eks_cluster_name eks_worker_node_name k8s_version node_enclave_cpu_limit node_enclave_memory_limit_mib)
 
 # Utility functions and definitions
 source "$SCRIPTS_DIR/utils.sh"

--- a/settings.json
+++ b/settings.json
@@ -3,5 +3,7 @@
   "instance_type" : "m5.2xlarge",
   "eks_cluster_name" : "eks-ne-cluster",
   "eks_worker_node_name" : "eks-ne-nodegroup",
-  "k8s_version" : "1.22"
+  "k8s_version" : "1.22",
+  "node_enclave_cpu_limit": 2,
+  "node_enclave_memory_limit_mib": 768
 }


### PR DESCRIPTION
- Make node-level vCPU and memory limits configurable and load them from settings.json
- Simplify user data section of the launch template.
- Remove memory limiting declarations from example applications' deployment specification.
Signed-off-by: Erdem Meydanli <meydanli@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
