### PR TITLE
Change amazonlinux version in Dockerfile.builder

### DIFF
--- a/container/builder/Dockerfile.builder
+++ b/container/builder/Dockerfile.builder
@@ -1,7 +1,7 @@
 # Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM amazonlinux
+FROM amazonlinux:2
 
 RUN amazon-linux-extras install aws-nitro-enclaves-cli && \
     yum install wget git aws-nitro-enclaves-cli-devel -y


### PR DESCRIPTION
[*Issue #25 Build error because missing amazon-linux-extras*](https://github.com/aws/aws-nitro-enclaves-with-k8s/issues/25)

*Description of changes:*
Add version to `Dockerfile.builder` to avoid missing `amazon-linux-extras` error during build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
