### PR TITLE
Update settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,10 +1,10 @@
 {
   "region" : "eu-central-1",
-  "instance_type" : "m5.2xlarge",
+  "instance_type" : "m7a.2xlarge",
   "eks_cluster_name" : "eks-ne-cluster",
   "eks_worker_node_name" : "eks-ne-nodegroup",
   "eks_worker_node_capacity": "1",
-  "k8s_version" : "1.22",
+  "k8s_version" : "1.30",
   "node_enclave_cpu_limit": 2,
   "node_enclave_memory_limit_mib": 768
 }


### PR DESCRIPTION
*Issue #, if available:*
1.22 EKS Version isn't supported now and m5.2xlarge is also uncompatible.

*Description of changes:*
- Changed to 1.30 EKS Version
- Updated the instance type as per compatible instance types for Nitro Enclave Feature

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
